### PR TITLE
Remove regex validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=benzaita
 NAME=chaossearch
 BINARY=terraform-provider-${NAME}
-VERSION=0.5.0
+VERSION=0.5.1
 OS_ARCH=linux_amd64
 
 default: install

--- a/chaossearch/resource_object_group.go
+++ b/chaossearch/resource_object_group.go
@@ -64,7 +64,6 @@ func resourceObjectGroup() *schema.Resource {
 				Default:      "",
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsValidRegExp,
 			},
 			"pattern": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
the regex flavour allowed by this validation is not aligned with the flavour allowed by the ChaosSearch API
