### PR TITLE
Lx 899 split og and indexing status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=benzaita
 NAME=chaossearch
 BINARY=terraform-provider-${NAME}
-VERSION=0.5.3
-OS_ARCH=linux_amd64
+VERSION=0.6.0
+OS_ARCH=darwin_amd64
 
 default: install
 

--- a/chaossearch/client/client.go
+++ b/chaossearch/client/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"time"
+	"encoding/json"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
@@ -81,6 +82,19 @@ func (client *Client) unmarshalXMLBody(bodyReader io.Reader, v interface{}) erro
 
 	if err := xml.Unmarshal(bodyAsBytes, v); err != nil {
 		return fmt.Errorf("Failed to unmarshal XML: %s", err)
+	}
+
+	return nil
+}
+
+func (client *Client) unmarshalJSONBody(bodyReader io.Reader, v interface{}) error {
+	bodyAsBytes, err := ioutil.ReadAll(bodyReader)
+	if err != nil {
+		return fmt.Errorf("Failed to read body: %s", err)
+	}
+
+	if err := json.Unmarshal(bodyAsBytes, v); err != nil {
+		return fmt.Errorf("Failed to unmarshal JSON: %s", err)
 	}
 
 	return nil

--- a/chaossearch/client/model.go
+++ b/chaossearch/client/model.go
@@ -53,3 +53,23 @@ type UpdateObjectGroupRequest struct {
 	Name           string
 	IndexRetention int
 }
+
+type ReadIndexingStateRequest struct {
+	ObjectGroupName string
+}
+
+type ReadBucketMetadataResponse struct {
+	Metadata map[string]BucketMetadata `json:"Metadata"`
+}
+
+// There are other nested structures that we don't marshal here because we don't need to.
+//  Feel free to add them in the future when needed
+type BucketMetadata struct {
+	Bucket string `json:"Bucket"`
+	State  string `json:"State"`
+}
+
+type IndexingState struct {
+	ObjectGroupName string
+	Active          bool
+}

--- a/chaossearch/client/model.go
+++ b/chaossearch/client/model.go
@@ -40,7 +40,7 @@ type CreateObjectGroupRequest struct {
 	IndexRetention   int
 }
 
-type SetActiveRequest struct {
+type UpdateIndexingStateRequest struct {
 	ObjectGroupName string
 	Active          bool
 }

--- a/chaossearch/client/model.go
+++ b/chaossearch/client/model.go
@@ -57,6 +57,11 @@ type ReadIndexingStateRequest struct {
 	ObjectGroupName string
 }
 
+type readBucketMetadataRequest struct {
+	BucketName string `json:"BucketName"`
+	Stats bool `json:"Stats"`
+}
+
 type IndexingState struct {
 	ObjectGroupName string
 	Active          bool

--- a/chaossearch/client/model.go
+++ b/chaossearch/client/model.go
@@ -25,7 +25,6 @@ type ReadObjectGroupResponse struct {
 	PartitionBy      string
 	SourceBucket     string
 	IndexRetention   int
-	Active           bool
 }
 
 type CreateObjectGroupRequest struct {

--- a/chaossearch/client/model.go
+++ b/chaossearch/client/model.go
@@ -58,17 +58,6 @@ type ReadIndexingStateRequest struct {
 	ObjectGroupName string
 }
 
-type ReadBucketMetadataResponse struct {
-	Metadata map[string]BucketMetadata `json:"Metadata"`
-}
-
-// There are other nested structures that we don't marshal here because we don't need to.
-//  Feel free to add them in the future when needed
-type BucketMetadata struct {
-	Bucket string `json:"Bucket"`
-	State  string `json:"State"`
-}
-
 type IndexingState struct {
 	ObjectGroupName string
 	Active          bool

--- a/chaossearch/client/operation_read_indexing_state.go
+++ b/chaossearch/client/operation_read_indexing_state.go
@@ -7,6 +7,18 @@ import (
 	"net/http"
 )
 
+
+type readBucketMetadataResponse struct {
+	Metadata map[string]bucketMetadata `json:"Metadata"`
+}
+
+// There are other nested structures that we don't marshal here because we don't need to.
+//  Feel free to add them in the future when needed
+type bucketMetadata struct {
+	Bucket string `json:"Bucket"`
+	State  string `json:"State"`
+}
+
 // For documentation see: https://docs.chaossearch.io/reference#bucketmodel
 func (client *Client) ReadIndexingState(ctx context.Context, req *ReadIndexingStateRequest) (*IndexingState, error) {
 	method := "GET"
@@ -16,7 +28,7 @@ func (client *Client) ReadIndexingState(ctx context.Context, req *ReadIndexingSt
 		return nil, fmt.Errorf("request failed: %s", err)
 	}
 
-	var response ReadBucketMetadataResponse
+	var response readBucketMetadataResponse
 	err = client.unmarshalJSONBody(responseBody, response)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %s", err)

--- a/chaossearch/client/operation_read_indexing_state.go
+++ b/chaossearch/client/operation_read_indexing_state.go
@@ -1,68 +1,71 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
 
-type readBucketMetadataResponse struct {
-	Metadata map[string]bucketMetadata `json:"Metadata"`
-}
-
 // There are other nested structures that we don't marshal here because we don't need to.
 //  Feel free to add them in the future when needed
-type bucketMetadata struct {
+type readBucketMetadataResponse struct {
 	Bucket string `json:"Bucket"`
 	State  string `json:"State"`
 }
 
 // For documentation see: https://docs.chaossearch.io/reference#bucketmodel
 func (client *Client) ReadIndexingState(ctx context.Context, req *ReadIndexingStateRequest) (*IndexingState, error) {
-	method := "GET"
+	method := "POST"
+	body := &readBucketMetadataRequest{
+		BucketName: req.ObjectGroupName,
+		Stats: false,
+	}
 
-	responseBody, err := makeGetBucketMetadataRequest(method, client, ctx)
+	response, err := makeGetBucketMetadataRequest(method, client, ctx, body)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %s", err)
 	}
 
-	var response readBucketMetadataResponse
-	err = client.unmarshalJSONBody(responseBody, response)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %s", err)
-	}
-
-	if _, ok := response.Metadata[req.ObjectGroupName]; !ok {
-		return nil, fmt.Errorf("response doesn't contain the needed Bucket metadata: %s", req.ObjectGroupName)
-	}
-
 	bucketMetadata := &IndexingState{
-		ObjectGroupName: req.ObjectGroupName,
+		ObjectGroupName: response.Bucket,
 		Active: false,
 	}
 
-	if response.Metadata[req.ObjectGroupName].State == "Active" {
+	if response.State == "Active" || response.State == "Idle" {
 		bucketMetadata.Active = true
 	}
 
 	return bucketMetadata, nil
 }
 
-func makeGetBucketMetadataRequest(method string, client *Client, ctx context.Context) (io.ReadCloser, error) {
+func makeGetBucketMetadataRequest(method string, client *Client, ctx context.Context, body *readBucketMetadataRequest) (*readBucketMetadataResponse, error) {
 	url := fmt.Sprintf("%s/Bucket/metadata", client.config.URL)
 
-	httpReq, err := http.NewRequestWithContext(ctx, method, url, nil)
+	jsonedBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal request body: %s", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(jsonedBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %s", err)
 	}
 
-	httpResp, err := client.signAndDo(httpReq, nil)
+	httpResp, err := client.signAndDo(httpReq, jsonedBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to %s to %s: %s", method, url, err)
 	}
 	defer httpResp.Body.Close()
 
-	return httpResp.Body, nil
+
+	var response readBucketMetadataResponse
+	err = client.unmarshalJSONBody(httpResp.Body, &response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %s", err)
+	}
+
+	return &response, nil
 }

--- a/chaossearch/client/operation_read_indexing_state.go
+++ b/chaossearch/client/operation_read_indexing_state.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// For documentation see: https://docs.chaossearch.io/reference#bucketmodel
+func (client *Client) ReadIndexingState(ctx context.Context, req *ReadIndexingStateRequest) (*IndexingState, error) {
+	method := "GET"
+
+	responseBody, err := makeGetBucketMetadataRequest(method, client, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %s", err)
+	}
+
+	var response ReadBucketMetadataResponse
+	err = client.unmarshalJSONBody(responseBody, response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %s", err)
+	}
+
+	if _, ok := response.Metadata[req.ObjectGroupName]; !ok {
+		return nil, fmt.Errorf("response doesn't contain the needed Bucket metadata: %s", req.ObjectGroupName)
+	}
+
+	bucketMetadata := &IndexingState{
+		ObjectGroupName: req.ObjectGroupName,
+		Active: false,
+	}
+
+	if response.Metadata[req.ObjectGroupName].State == "Active" {
+		bucketMetadata.Active = true
+	}
+
+	return bucketMetadata, nil
+}
+
+func makeGetBucketMetadataRequest(method string, client *Client, ctx context.Context) (io.ReadCloser, error) {
+	url := fmt.Sprintf("%s/Bucket/metadata", client.config.URL)
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %s", err)
+	}
+
+	httpResp, err := client.signAndDo(httpReq, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to %s to %s: %s", method, url, err)
+	}
+	defer httpResp.Body.Close()
+
+	return httpResp.Body, nil
+}

--- a/chaossearch/client/operation_read_object_group.go
+++ b/chaossearch/client/operation_read_object_group.go
@@ -64,10 +64,6 @@ func mapBucketTaggingToResponse(tagging *s3.GetBucketTaggingOutput, v *ReadObjec
 		return err
 	}
 
-	if err := readJSONTagValue(tagging, "cs3.modeled", &v.Active); err != nil {
-		return err
-	}
-
 	var filterObject struct {
 		Type string `json:"_type"`
 	}

--- a/chaossearch/client/operation_update_indexing_state.go
+++ b/chaossearch/client/operation_update_indexing_state.go
@@ -8,7 +8,8 @@ import (
 	"net/http"
 )
 
-func (client *Client) SetActive(ctx context.Context, req *SetActiveRequest) error {
+// For documentation see: https://docs.chaossearch.io/reference#bucketmodel
+func (client *Client) UpdateIndexingState(ctx context.Context, req *SetActiveRequest) error {
 	method := "POST"
 	url := fmt.Sprintf("%s/Bucket/model", client.config.URL)
 

--- a/chaossearch/client/operation_update_indexing_state.go
+++ b/chaossearch/client/operation_update_indexing_state.go
@@ -9,11 +9,11 @@ import (
 )
 
 // For documentation see: https://docs.chaossearch.io/reference#bucketmodel
-func (client *Client) UpdateIndexingState(ctx context.Context, req *SetActiveRequest) error {
+func (client *Client) UpdateIndexingState(ctx context.Context, req *UpdateIndexingStateRequest) error {
 	method := "POST"
 	url := fmt.Sprintf("%s/Bucket/model", client.config.URL)
 
-	bodyAsBytes, err := marshalSetActiveRequest(req)
+	bodyAsBytes, err := marshalUpdateIndexingStateRequest(req)
 	if err != nil {
 		return err
 	}
@@ -32,7 +32,7 @@ func (client *Client) UpdateIndexingState(ctx context.Context, req *SetActiveReq
 	return nil
 }
 
-func marshalSetActiveRequest(req *SetActiveRequest) ([]byte, error) {
+func marshalUpdateIndexingStateRequest(req *UpdateIndexingStateRequest) ([]byte, error) {
 	var modelMode int
 
 	if req.Active {

--- a/chaossearch/provider.go
+++ b/chaossearch/provider.go
@@ -41,6 +41,7 @@ func Provider() *schema.Provider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"chaossearch_object_group": resourceObjectGroup(),
+			"chaossearch_indexing_state": resourceIndexingState(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"chaossearch_object_groups": dataSourceObjectGroups(),

--- a/chaossearch/resource_indexing_state.go
+++ b/chaossearch/resource_indexing_state.go
@@ -53,9 +53,19 @@ func resourceIndexingStateCreate(ctx context.Context, data *schema.ResourceData,
 func resourceIndexingStateRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 
-	// There is no request that is similar to getting an indexing state in ChaosSearch API,
-	//  so we cannot retrieve it, therefore this function is kept for the sake of being
-	//  compliant with Terraform providers standard, but it doesn't do anything
+	c := meta.(*ProviderMeta).Client
+
+	readIndexingStateRequest := &client.ReadIndexingStateRequest{
+		ObjectGroupName: data.Get("objectGroupName").(string),
+	}
+
+	resp, err := c.ReadIndexingState(ctx, readIndexingStateRequest)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(resp.ObjectGroupName)
+	data.Set("Active", resp.Active)
 
 	return diags
 }

--- a/chaossearch/resource_indexing_state.go
+++ b/chaossearch/resource_indexing_state.go
@@ -41,7 +41,7 @@ func resourceIndexingStateCreate(ctx context.Context, data *schema.ResourceData,
 		Active:          data.Get("active").(bool),
 	}
 
-	if err := c.SetActive(ctx, setActiveRequest); err != nil {
+	if err := c.UpdateIndexingState(ctx, setActiveRequest); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -67,7 +67,7 @@ func resourceIndexingStateUpdate(ctx context.Context, data *schema.ResourceData,
 		ObjectGroupName: data.Get("objectGroupName").(string),
 		Active:          data.Get("active").(bool),
 	}
-	if err := c.SetActive(ctx, setActiveRequest); err != nil {
+	if err := c.UpdateIndexingState(ctx, setActiveRequest); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -81,7 +81,7 @@ func resourceIndexingStateDelete(ctx context.Context, data *schema.ResourceData,
 		ObjectGroupName: data.Get("objectGroupName").(string),
 		Active:          false,
 	}
-	if err := c.SetActive(ctx, stopIndexingRequest); err != nil {
+	if err := c.UpdateIndexingState(ctx, stopIndexingRequest); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/chaossearch/resource_indexing_state.go
+++ b/chaossearch/resource_indexing_state.go
@@ -18,7 +18,7 @@ func resourceIndexingState() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
-			"objectGroupName": {
+			"object_group_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -37,7 +37,7 @@ func resourceIndexingStateCreate(ctx context.Context, data *schema.ResourceData,
 	c := meta.(*ProviderMeta).Client
 
 	setActiveRequest := &client.SetActiveRequest{
-		ObjectGroupName: data.Get("objectGroupName").(string),
+		ObjectGroupName: data.Get("object_group_name").(string),
 		Active:          data.Get("active").(bool),
 	}
 
@@ -45,7 +45,7 @@ func resourceIndexingStateCreate(ctx context.Context, data *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	data.SetId(data.Get("objectGroupName").(string))
+	data.SetId(data.Get("object_group_name").(string))
 
 	return resourceIndexingStateRead(ctx, data, meta)
 }
@@ -56,7 +56,7 @@ func resourceIndexingStateRead(ctx context.Context, data *schema.ResourceData, m
 	c := meta.(*ProviderMeta).Client
 
 	readIndexingStateRequest := &client.ReadIndexingStateRequest{
-		ObjectGroupName: data.Get("objectGroupName").(string),
+		ObjectGroupName: data.Get("object_group_name").(string),
 	}
 
 	resp, err := c.ReadIndexingState(ctx, readIndexingStateRequest)
@@ -74,7 +74,7 @@ func resourceIndexingStateUpdate(ctx context.Context, data *schema.ResourceData,
 	c := meta.(*ProviderMeta).Client
 
 	setActiveRequest := &client.SetActiveRequest{
-		ObjectGroupName: data.Get("objectGroupName").(string),
+		ObjectGroupName: data.Get("object_group_name").(string),
 		Active:          data.Get("active").(bool),
 	}
 	if err := c.UpdateIndexingState(ctx, setActiveRequest); err != nil {
@@ -88,7 +88,7 @@ func resourceIndexingStateDelete(ctx context.Context, data *schema.ResourceData,
 	c := meta.(*ProviderMeta).Client
 
 	stopIndexingRequest := &client.SetActiveRequest{
-		ObjectGroupName: data.Get("objectGroupName").(string),
+		ObjectGroupName: data.Get("object_group_name").(string),
 		Active:          false,
 	}
 	if err := c.UpdateIndexingState(ctx, stopIndexingRequest); err != nil {

--- a/chaossearch/resource_indexing_state.go
+++ b/chaossearch/resource_indexing_state.go
@@ -36,12 +36,12 @@ func resourceIndexingState() *schema.Resource {
 func resourceIndexingStateCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*ProviderMeta).Client
 
-	setActiveRequest := &client.SetActiveRequest{
+	updateIndexingStateRequest := &client.UpdateIndexingStateRequest{
 		ObjectGroupName: data.Get("object_group_name").(string),
 		Active:          data.Get("active").(bool),
 	}
 
-	if err := c.UpdateIndexingState(ctx, setActiveRequest); err != nil {
+	if err := c.UpdateIndexingState(ctx, updateIndexingStateRequest); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -65,7 +65,7 @@ func resourceIndexingStateRead(ctx context.Context, data *schema.ResourceData, m
 	}
 
 	data.SetId(resp.ObjectGroupName)
-	data.Set("Active", resp.Active)
+	data.Set("active", resp.Active)
 
 	return diags
 }
@@ -73,11 +73,11 @@ func resourceIndexingStateRead(ctx context.Context, data *schema.ResourceData, m
 func resourceIndexingStateUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*ProviderMeta).Client
 
-	setActiveRequest := &client.SetActiveRequest{
+	updateIndexingStateRequest := &client.UpdateIndexingStateRequest{
 		ObjectGroupName: data.Get("object_group_name").(string),
 		Active:          data.Get("active").(bool),
 	}
-	if err := c.UpdateIndexingState(ctx, setActiveRequest); err != nil {
+	if err := c.UpdateIndexingState(ctx, updateIndexingStateRequest); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -87,7 +87,7 @@ func resourceIndexingStateUpdate(ctx context.Context, data *schema.ResourceData,
 func resourceIndexingStateDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*ProviderMeta).Client
 
-	stopIndexingRequest := &client.SetActiveRequest{
+	stopIndexingRequest := &client.UpdateIndexingStateRequest{
 		ObjectGroupName: data.Get("object_group_name").(string),
 		Active:          false,
 	}

--- a/chaossearch/resource_indexing_state.go
+++ b/chaossearch/resource_indexing_state.go
@@ -1,0 +1,91 @@
+package chaossearch
+
+import (
+	"context"
+	"terraform-provider-chaossearch/chaossearch/client"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceIndexingState() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIndexingStateCreate,
+		ReadContext:   resourceIndexingStateRead,
+		UpdateContext: resourceIndexingStateUpdate,
+		DeleteContext: resourceIndexingStateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"objectGroupName": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"active": {
+				Type:        schema.TypeBool,
+				Description: "Whether the live indexing should be running or not",
+				Required:    true,
+				ForceNew:    false,
+			},
+		},
+	}
+}
+
+func resourceIndexingStateCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*ProviderMeta).Client
+
+	setActiveRequest := &client.SetActiveRequest{
+		ObjectGroupName: data.Get("objectGroupName").(string),
+		Active:          data.Get("active").(bool),
+	}
+
+	if err := c.SetActive(ctx, setActiveRequest); err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(data.Get("objectGroupName").(string))
+
+	return resourceIndexingStateRead(ctx, data, meta)
+}
+
+func resourceIndexingStateRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	// There is no request that is similar to getting an indexing state in ChaosSearch API,
+	//  so we cannot retrieve it, therefore this function is kept for the sake of being
+	//  compliant with Terraform providers standard, but it doesn't do anything
+
+	return diags
+}
+
+func resourceIndexingStateUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*ProviderMeta).Client
+
+	setActiveRequest := &client.SetActiveRequest{
+		ObjectGroupName: data.Get("objectGroupName").(string),
+		Active:          data.Get("active").(bool),
+	}
+	if err := c.SetActive(ctx, setActiveRequest); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceIndexingStateRead(ctx, data, meta)
+}
+
+func resourceIndexingStateDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*ProviderMeta).Client
+
+	stopIndexingRequest := &client.SetActiveRequest{
+		ObjectGroupName: data.Get("objectGroupName").(string),
+		Active:          false,
+	}
+	if err := c.SetActive(ctx, stopIndexingRequest); err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId("")
+
+	return nil
+}

--- a/chaossearch/resource_object_group.go
+++ b/chaossearch/resource_object_group.go
@@ -78,12 +78,6 @@ func resourceObjectGroup() *schema.Resource {
 				Optional:    true,
 				ForceNew:    false,
 			},
-			"active": {
-				Type:        schema.TypeBool,
-				Description: "Whether the live indexing should be running or not",
-				Required:    true,
-				ForceNew:    false,
-			},
 
 			// Workaround. Otherwise Terraform fails with "All fields are ForceNew or Computed w/out Optional, Update is superfluous"
 			"description": {
@@ -114,15 +108,6 @@ func resourceObjectGroupCreate(ctx context.Context, data *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	setActiveRequest := &client.SetActiveRequest{
-		ObjectGroupName: data.Get("name").(string),
-		Active:          data.Get("active").(bool),
-	}
-
-	if err := c.SetActive(ctx, setActiveRequest); err != nil {
-		return diag.FromErr(err)
-	}
-
 	data.SetId(data.Get("name").(string))
 
 	return resourceObjectGroupRead(ctx, data, meta)
@@ -146,7 +131,6 @@ func resourceObjectGroupRead(ctx context.Context, data *schema.ResourceData, met
 	data.Set("format", resp.Format)
 	data.Set("live_events_sqs_arn", resp.LiveEventsSqsArn)
 	data.Set("index_retention", resp.IndexRetention)
-	data.Set("active", resp.Active)
 
 	// When the object in an Object Group use no compression, you need to create it with
 	// `compression = ""`. However, when querying an Object Group whose object are not
@@ -169,14 +153,6 @@ func resourceObjectGroupRead(ctx context.Context, data *schema.ResourceData, met
 func resourceObjectGroupUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*ProviderMeta).Client
 
-	setActiveRequest := &client.SetActiveRequest{
-		ObjectGroupName: data.Get("name").(string),
-		Active:          data.Get("active").(bool),
-	}
-	if err := c.SetActive(ctx, setActiveRequest); err != nil {
-		return diag.FromErr(err)
-	}
-
 	updateObjectGroupRequest := &client.UpdateObjectGroupRequest{
 		Name:           data.Get("name").(string),
 		IndexRetention: data.Get("index_retention").(int),
@@ -191,14 +167,6 @@ func resourceObjectGroupUpdate(ctx context.Context, data *schema.ResourceData, m
 
 func resourceObjectGroupDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*ProviderMeta).Client
-
-	stopIndexingRequest := &client.SetActiveRequest{
-		ObjectGroupName: data.Get("name").(string),
-		Active:          false,
-	}
-	if err := c.SetActive(ctx, stopIndexingRequest); err != nil {
-		return diag.FromErr(err)
-	}
 
 	deleteObjectGroupRequest := &client.DeleteObjectGroupRequest{
 		Name: data.Get("name").(string),

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -28,3 +28,8 @@ resource "chaossearch_object_group" "my-object-group" {
 
   partition_by = "<regex>"
 }
+
+resource "chaossearch_indexing_state" "my-object-group" {
+  object_group_name = chaossearch_object_group.my-object-group.name
+  active = true
+}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,18 +1,23 @@
 terraform {
   required_providers {
     chaossearch = {
-      versions = ["0.2"]
+      versions = ["0.6.0"]
       source = "benzaita/chaossearch"
     }
   }
 }
 
-provider "chaossearch" {}
+provider "chaossearch" {
+    url               = "http://example.com"
+    access_key_id     = "chaossearch_access_key_id"
+    secret_access_key = "chaossearch_secret_access_key"
+    region            = "eu-west-1"
+}
 
 resource "chaossearch_object_group" "my-object-group" {
   name = "my-object-group"
   source_bucket = "<s3 bucket name>"
-  live_events_sqs_arn ="<sqs arn>"
+  live_events_sqs_arn ="arn:aws:sqs:sqs_sqs"
 
   filter_json = jsonencode({
     AND = [


### PR DESCRIPTION
CS API around the `active` flag is far from being something reminding CRUD, so I made CUD actions to be at the end just update calls, and Read action is a dummy that is there only to be terraform compliant.
I'm going to ask CS maybe there is a way to fetch the status of indexing. If it is - I'll update the PR