### PR TITLE
Add column renames attribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 	go build -o ${BINARY}
 
 run: install
-	cd examples && terraform init && terraform apply
+	cd examples && rm -rf .terraform && terraform init && terraform apply
 
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NAMESPACE=benzaita
 NAME=chaossearch
 BINARY=terraform-provider-${NAME}
 VERSION=0.6.2
-OS_ARCH=darwin_amd64
+OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
 
 default: install
 

--- a/chaossearch/client/client.go
+++ b/chaossearch/client/client.go
@@ -2,8 +2,8 @@ package client
 
 import (
 	"bytes"
-	"encoding/xml"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -80,6 +80,8 @@ func (client *Client) unmarshalXMLBody(bodyReader io.Reader, v interface{}) erro
 		return fmt.Errorf("Failed to read body: %s", err)
 	}
 
+	log.Printf("Unmarshalling XML: %s\n", bodyAsBytes)
+
 	if err := xml.Unmarshal(bodyAsBytes, v); err != nil {
 		return fmt.Errorf("Failed to unmarshal XML: %s", err)
 	}
@@ -92,6 +94,8 @@ func (client *Client) unmarshalJSONBody(bodyReader io.Reader, v interface{}) err
 	if err != nil {
 		return fmt.Errorf("Failed to read body: %s", err)
 	}
+
+	log.Printf("Unmarshalling JSON: %s\n", bodyAsBytes)
 
 	if err := json.Unmarshal(bodyAsBytes, v); err != nil {
 		return fmt.Errorf("Failed to unmarshal JSON: %s", err)

--- a/chaossearch/client/model.go
+++ b/chaossearch/client/model.go
@@ -26,6 +26,7 @@ type ReadObjectGroupResponse struct {
 	PartitionBy      string
 	SourceBucket     string
 	IndexRetention   int
+	ColumnRenames    map[string]string
 }
 
 type CreateObjectGroupRequest struct {
@@ -38,6 +39,7 @@ type CreateObjectGroupRequest struct {
 	SourceBucket     string
 	Pattern          string
 	IndexRetention   int
+	ColumnRenames    map[string]interface{}
 }
 
 type UpdateIndexingStateRequest struct {
@@ -60,7 +62,7 @@ type ReadIndexingStateRequest struct {
 
 type readBucketMetadataRequest struct {
 	BucketName string `json:"BucketName"`
-	Stats bool `json:"Stats"`
+	Stats      bool   `json:"Stats"`
 }
 
 type IndexingState struct {

--- a/chaossearch/client/operation_create_object_group.go
+++ b/chaossearch/client/operation_create_object_group.go
@@ -50,6 +50,11 @@ func marshalCreateObjectGroupRequest(req *CreateObjectGroupRequest) ([]byte, err
 		},
 	}
 
+	if len(req.ColumnRenames) > 0 {
+		var options = body["options"].(map[string]interface{})
+		options["colRenames"] = req.ColumnRenames
+	}
+
 	if req.Compression != "" {
 		var options = body["options"].(map[string]interface{})
 		options["compression"] = req.Compression

--- a/chaossearch/client/operation_read_object_group.go
+++ b/chaossearch/client/operation_read_object_group.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"log"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -22,11 +22,11 @@ func (l appLogger) Log(args ...interface{}) {
 func (client *Client) ReadObjectGroup(ctx context.Context, req *ReadObjectGroupRequest) (*ReadObjectGroupResponse, error) {
 	var resp ReadObjectGroupResponse
 
-	if err:= client.readAttributesFromBucketTagging(ctx, req, &resp); err !=nil {
+	if err := client.readAttributesFromBucketTagging(ctx, req, &resp); err != nil {
 		return nil, err
 	}
 
-	if err:= client.readAttributesFromDatasetEndpoint(ctx, req, &resp); err !=nil {
+	if err := client.readAttributesFromDatasetEndpoint(ctx, req, &resp); err != nil {
 		return nil, err
 	}
 
@@ -35,7 +35,7 @@ func (client *Client) ReadObjectGroup(ctx context.Context, req *ReadObjectGroupR
 	return &resp, nil
 }
 
-func (client *Client ) readAttributesFromDatasetEndpoint(ctx context.Context, req *ReadObjectGroupRequest,resp *ReadObjectGroupResponse ) error {
+func (client *Client) readAttributesFromDatasetEndpoint(ctx context.Context, req *ReadObjectGroupRequest, resp *ReadObjectGroupResponse) error {
 	method := "GET"
 	url := fmt.Sprintf("%s/Bucket/dataset/name/%s", client.config.URL, req.ID)
 
@@ -44,7 +44,7 @@ func (client *Client ) readAttributesFromDatasetEndpoint(ctx context.Context, re
 		return fmt.Errorf("Failed to create request: %s", err)
 	}
 
-	httpResp, err := client.signAndDo(httpReq,nil)
+	httpResp, err := client.signAndDo(httpReq, nil)
 	if err != nil {
 		return fmt.Errorf("Failed to %s to %s: %s", method, url, err)
 	}
@@ -52,17 +52,21 @@ func (client *Client ) readAttributesFromDatasetEndpoint(ctx context.Context, re
 
 	var getDatasetResp struct {
 		PartitionBy string `json:"partitionBy"`
+		Options     struct {
+			ColumnRenames map[string]string `json:"colRenames"`
+		} `json:"options"`
 	}
 	if err := client.unmarshalJSONBody(httpResp.Body, &getDatasetResp); err != nil {
 		return fmt.Errorf("Failed to unmarshal JSON response body: %s", err)
 	}
 
 	resp.PartitionBy = getDatasetResp.PartitionBy
+	resp.ColumnRenames = getDatasetResp.Options.ColumnRenames
 
 	return nil
 }
 
-func (client *Client ) readAttributesFromBucketTagging(ctx context.Context, req *ReadObjectGroupRequest,resp *ReadObjectGroupResponse ) error {
+func (client *Client) readAttributesFromBucketTagging(ctx context.Context, req *ReadObjectGroupRequest, resp *ReadObjectGroupResponse) error {
 	session, err := session.NewSession(&aws.Config{
 		Credentials:      credentials.NewStaticCredentials(client.config.AccessKeyID, client.config.SecretAccessKey, ""),
 		Endpoint:         aws.String(fmt.Sprintf("%s/V1", client.config.URL)),
@@ -89,7 +93,7 @@ func (client *Client ) readAttributesFromBucketTagging(ctx context.Context, req 
 		return fmt.Errorf("Failed to unmarshal XML response body: %s", err)
 	}
 
-	return  nil
+	return nil
 }
 
 func mapBucketTaggingToResponse(tagging *s3.GetBucketTaggingOutput, v *ReadObjectGroupResponse) error {
@@ -106,7 +110,7 @@ func mapBucketTaggingToResponse(tagging *s3.GetBucketTaggingOutput, v *ReadObjec
 	}
 
 	var filterObject struct {
-		Type string `json:"_type"`
+		Type    string `json:"_type"`
 		Pattern string `json:"pattern"`
 	}
 	if err := readJSONTagValue(tagging, "cs3.dataset-format", &filterObject); err != nil {

--- a/chaossearch/resource_object_group.go
+++ b/chaossearch/resource_object_group.go
@@ -59,10 +59,10 @@ func resourceObjectGroup() *schema.Resource {
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^arn:aws:sqs:.*`), `must be an SQS ARN: "arn:aws:sqs:..."`),
 			},
 			"partition_by": {
-				Type:         schema.TypeString,
-				Default:      "",
-				Optional:     true,
-				ForceNew:     true,
+				Type:     schema.TypeString,
+				Default:  "",
+				Optional: true,
+				ForceNew: true,
 			},
 			"pattern": {
 				Type:     schema.TypeString,
@@ -76,6 +76,16 @@ func resourceObjectGroup() *schema.Resource {
 				Description: "Number of days to keep the data before deleting it",
 				Optional:    true,
 				ForceNew:    false,
+			},
+			"column_renames": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:    true,
+				Default:     make(map[string]string),
+				ForceNew:    true,
+				Description: "A map specifying names of columns to rename (keys) and what to rename them to (values)",
 			},
 
 			// Workaround. Otherwise Terraform fails with "All fields are ForceNew or Computed w/out Optional, Update is superfluous"
@@ -101,6 +111,7 @@ func resourceObjectGroupCreate(ctx context.Context, data *schema.ResourceData, m
 		PartitionBy:      data.Get("partition_by").(string),
 		Pattern:          data.Get("pattern").(string),
 		IndexRetention:   data.Get("index_retention").(int),
+		ColumnRenames:    data.Get("column_renames").(map[string]interface{}),
 	}
 
 	if err := c.CreateObjectGroup(ctx, createObjectGroupRequest); err != nil {


### PR DESCRIPTION
This PR adds the `column_renames` attribute. It allows to define a mapping of column names to apply while ingesting logs.

For example, with
```
...
column_renames = {
  eventTime = "Timestamp"
}
...
```

the following input:

```json
{ "eventTime": 123456789, "message": "Hello world!" }
```

will be ingested by the Object Group as:

```
Timestamp: 123456789
message: "Hello world!"
```