### PR TITLE
OX-1168 Work around for non-versioned breaking API change in ChaosSearch

### DIFF
--- a/client/operation_read_object_group.go
+++ b/client/operation_read_object_group.go
@@ -19,7 +19,8 @@ func (l appLogger) Log(args ...interface{}) {
 	log.Printf("AWS: %+v", args...)
 }
 
-// processFilterJSON takes a JSON string as input, checks the structure of the "regex" key,
+// BUG: ChaosSearch breaking API change now uses two representations of "regex", one as an object, the other as a string.
+// The function `processFilterJSON` takes a JSON string as input, checks the structure of the "regex" key,
 // and returns a modified JSON string according to the specified rules.
 // For example:
 //     `{"AND":[{"field":"key","regex":{"pattern":".*","strict":true}}]}`

--- a/client/operation_read_object_group.go
+++ b/client/operation_read_object_group.go
@@ -39,11 +39,16 @@ func recoverFilterJSON(input string) (string, error) {
         regex := entry["regex"]                // Access the "regex" key.
 
         // Check the type of the "regex" key.
-        switch regex.(type) {
+        switch regexValue := regex.(type) {
         case map[string]interface{}:
-            // If "regex" is a map, set it to the value of the "pattern" key.
-            regexMap := regex.(map[string]interface{})
-            entry["regex"] = regexMap["pattern"]
+            // If "regex" is a map, check if the "strict" key is true.
+            if strict, ok := regexValue["strict"].(bool); ok && strict {
+                // If "strict" is true, set "regex" to the value of the "pattern" key.
+                entry["regex"] = regexValue["pattern"]
+            } else {
+                // If "strict" is not true, return an error.
+                return "", fmt.Errorf("strict key is not true")
+            }
         case string:
             // If "regex" is a string, no action is needed.
         default:

--- a/client/operation_read_object_group.go
+++ b/client/operation_read_object_group.go
@@ -20,13 +20,13 @@ func (l appLogger) Log(args ...interface{}) {
 }
 
 // BUG: ChaosSearch breaking API change now uses two representations of "regex", one as an object, the other as a string.
-// The function `processFilterJSON` takes a JSON string as input, checks the structure of the "regex" key,
+// The function `recoverFilterJSON` takes a JSON string as input, checks the structure of the "regex" key,
 // and returns a modified JSON string according to the specified rules.
 // For example:
 //     `{"AND":[{"field":"key","regex":{"pattern":".*","strict":true}}]}`
 // is converted back into
 //     `{"AND":[{"field":"key","regex":".*"}]}`
-func processFilterJSON(input string) (string, error) {
+func recoverFilterJSON(input string) (string, error) {
     // Unmarshal the input JSON string into a map structure.
     var data map[string]interface{}
     if err := json.Unmarshal([]byte(input), &data); err != nil {
@@ -187,8 +187,9 @@ func mapBucketTaggingToResponse(tagging *s3.GetBucketTaggingOutput, v *ReadObjec
 
 	// NOTE: this is to work around a non-versioned breaking API change in ChaosSearch.
 	// The API might return a slightly modified JSON string.
+	// Here, we recover the "original" format in case that happens.
 	inputFilterJSON := v.FilterJSON
-	outputJSON, err := processFilterJSON(inputFilterJSON)
+	outputJSON, err := recoverFilterJSON(inputFilterJSON)
     if err != nil {
         return err
     } else {

--- a/terraformprovider/Makefile
+++ b/terraformprovider/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=benzaita
 NAME=chaossearch
 BINARY=terraform-provider-${NAME}
-VERSION=0.12.2
+VERSION=0.12.3
 OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
 
 default: install


### PR DESCRIPTION
**Problem**
ChaosSearch introduced a breaking change where the JSON string in the **predicate** tag is modified and stored in the object group.
When reading the object group data, the modified JSON string is returned and not the "original" one.

**Proposed Solution**

This workaround adds a function **processFilterJSON** that returns the "original" format, in case the modified schema is detected.

For example:
`{"AND":[{"field":"key","regex":{"pattern":".*","strict":true}}]}`
is converted back into
`{"AND":[{"field":"key","regex":".*"}]}` with `regex = the value of pattern`

Whereas
`{"AND":[{"field":"key","regex":".*"}]}` is returned as is.